### PR TITLE
fix: prevent empty webhook body from silent json_encode failure

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -388,11 +388,16 @@ class Data extends CoreHelper
 
         $encoded = json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE);
         if ($encoded === false) {
-            $this->_logger->critical('Webhook: json_encode failed — ' . json_last_error_msg(), [
+            $errorMsg = json_last_error_msg();
+            $this->_logger->critical('Webhook: json_encode failed — ' . $errorMsg, [
                 'increment_id' => $item->getIncrementId(),
                 'entity_id' => $item->getEntityId(),
             ]);
-            return '{}';
+            return json_encode([
+                'error' => 'json_encode failed: ' . $errorMsg,
+                'increment_id' => (string) $item->getIncrementId(),
+                'entity_id' => (string) $item->getEntityId(),
+            ], JSON_INVALID_UTF8_SUBSTITUTE) ?: '{}';
         }
 
         return $encoded;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -324,17 +324,41 @@ class Data extends CoreHelper
             $result["storeUrl"] = $item->getStore()->getBaseUrl();
             $result["items"] = [];
             foreach ($item->getItems() as $orderItem) {
-                /** @var Product $product */
-                $product = $orderItem->getProduct();
-                [$image, $productUrl] = $this->getProductUrls($product);
-                $result["items"][] = [
-                    "name" => $orderItem->getName(),
-                    "sku" => $orderItem->getSku(),
-                    "product_url" => $productUrl,
-                    "image_url" => $image,
-                    "product_type" => $product->getTypeId(),
-                    "qty_ordered" => $orderItem->getQtyOrdered(),
-                ];
+                try {
+                    /** @var Product $product */
+                    $product = $orderItem->getProduct();
+                    if ($product) {
+                        [$image, $productUrl] = $this->getProductUrls($product);
+                        $result["items"][] = [
+                            "name" => $orderItem->getName(),
+                            "sku" => $orderItem->getSku(),
+                            "product_url" => $productUrl,
+                            "image_url" => $image,
+                            "product_type" => $product->getTypeId(),
+                            "qty_ordered" => $orderItem->getQtyOrdered(),
+                        ];
+                    } else {
+                        $this->_logger->warning('Webhook: product not found for order item SKU ' . $orderItem->getSku() . ', skipping from payload');
+                        $result["items"][] = [
+                            "name" => $orderItem->getName(),
+                            "sku" => $orderItem->getSku(),
+                            "product_url" => null,
+                            "image_url" => null,
+                            "product_type" => null,
+                            "qty_ordered" => $orderItem->getQtyOrdered(),
+                        ];
+                    }
+                } catch (\Exception $e) {
+                    $this->_logger->warning('Webhook: failed to load product for order item SKU ' . $orderItem->getSku() . ': ' . $e->getMessage());
+                    $result["items"][] = [
+                        "name" => $orderItem->getName(),
+                        "sku" => $orderItem->getSku(),
+                        "product_url" => null,
+                        "image_url" => null,
+                        "product_type" => null,
+                        "qty_ordered" => $orderItem->getQtyOrdered(),
+                    ];
+                }
             }
         }
 
@@ -362,7 +386,16 @@ class Data extends CoreHelper
             }
         }
 
-        return json_encode($result);
+        $encoded = json_encode($result, JSON_INVALID_UTF8_SUBSTITUTE);
+        if ($encoded === false) {
+            $this->_logger->critical('Webhook: json_encode failed — ' . json_last_error_msg(), [
+                'increment_id' => $item->getIncrementId(),
+                'entity_id' => $item->getEntityId(),
+            ]);
+            return '{}';
+        }
+
+        return $encoded;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add `JSON_INVALID_UTF8_SUBSTITUTE` flag to `json_encode()` in `generateItemJsonString()` to handle non-UTF8 characters in order/address data (common with international customers)
- Log a `critical` error with order details if `json_encode` still fails, and return `'{}'` instead of boolean `false` — prevents the webhook from being sent with a completely empty body
- Wrap product fetch in `try/catch` with null check so deleted or disabled products don't break the entire payload — the item is still included with nulled product-specific fields

## Context
Customer reported webhooks being triggered successfully (HTTP 202 from parcelLab) but with an empty request body. Root cause: `json_encode()` silently returns `false` when encountering non-UTF8 data, which gets coerced to an empty string by CURL.

## Test plan
- [ ] Trigger an order webhook with an address containing non-UTF8 characters (e.g. Latin-1 encoded `ä`, `ö`, `ü`) — body should now contain the data with substituted characters
- [ ] Trigger an order webhook where one of the ordered products has been deleted — payload should include the item with `null` for `product_url`, `image_url`, `product_type`
- [ ] Check `var/log/system.log` for `Webhook:` prefixed messages when above scenarios occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)